### PR TITLE
MasterNodes: run in "safe mode"

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -680,9 +680,9 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         std::string errorMessage = "";
         if(!mnEngineSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)){
-            LogPrintf("dsee - Got bad masternode address signature\n");
-            Misbehaving(pfrom->GetId(), 100);
-            return;
+            LogPrintf("dsee - WARNING - Could not verify masternode address signature\n");
+            //Misbehaving(pfrom->GetId(), 100);
+            //return;
         }
 
         //search existing masternode list, this is where we update existing masternodes with new dsee broadcasts
@@ -841,9 +841,9 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
                 std::string errorMessage = "";
                 if(!mnEngineSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage))
                 {
-                    LogPrintf("dseep - Got bad masternode address signature %s \n", vin.ToString().c_str());
+                    LogPrintf("dseep - WARNING - Could not verify masternode address signature %s \n", vin.ToString().c_str());
                     //Misbehaving(pfrom->GetId(), 100);
-                    return;
+                    //return;
                 }
 
                 pmn->lastDseep = sigTime;
@@ -897,8 +897,9 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
                 std::string errorMessage = "";
                 if(!mnEngineSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage))
                 {
-                    LogPrintf("mvote - Got bad Masternode address signature %s \n", vin.ToString().c_str());
-                    return;
+                    LogPrintf("mvote - WARNING - Could not verify masternode address signature %s \n", vin.ToString().c_str());
+                    //Misbehaving(pfrom->GetId(), 100);
+                    //return;
                 }
 
                 pmn->nVote = nVote;

--- a/src/mnengine.cpp
+++ b/src/mnengine.cpp
@@ -1154,7 +1154,8 @@ bool CMNengineQueue::CheckSignature()
         std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(time) + boost::lexical_cast<std::string>(ready);
         std::string errorMessage = "";
         if(!mnEngineSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage)){
-            return error("CMNengineQueue::CheckSignature() - Got bad Masternode address signature %s \n", vin.ToString().c_str());
+            LogPrintf("CMNengineQueue::CheckSignature() - WARNING - Could not verify masternode address signature %s \n", vin.ToString().c_str());
+            //return error("CMNengineQueue::CheckSignature() - Got bad Masternode address signature %s \n", vin.ToString().c_str());
         }
 
         return true;


### PR DESCRIPTION
Changelog

- Run masternodes in "safe mode", assume winner signature is valid (TODO: rewrite signature to verify public key instead of private key then re-enable this section properly)